### PR TITLE
Add drafts to collections to avoid breaking panel

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,13 +15,13 @@ Kirby::plugin('tristanb/kirby-shopify', [
     ],
     'collections' => [
       'kirby-shopify.productsPage' => function ($site) {
-        return $site->pages()->filterBy('intendedTemplate', 'shopify.products')->first();
+        return $site->pages()->add($site->drafts())->filterBy('intendedTemplate', 'shopify.products')->first();
       },
       'kirby-shopify.products' => function ($site) {
         return collection('kirby-shopify.productsPage')->children();
       },
       'kirby-shopify.collectionsPage' => function ($site) {
-        return $site->pages()->filterBy('intendedTemplate', 'shopify.collections')->first();
+        return $site->pages()->add($site->drafts())->filterBy('intendedTemplate', 'shopify.collections')->first();
       },
       'kirby-shopify.collections' => function ($site) {
         return collection('kirby-shopify.collectionsPage')->children();


### PR DESCRIPTION
This allows a products/collections page to be changed to Draft status. 

Still breaks Product Page preview - can't figure out how to avoid that - but at least allows the end user to see the page in the panel as normal, and change the status back to Public or Unlisted.

Fixes #6 